### PR TITLE
simplify json integration + fix null deref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,10 @@ add_subdirectory(src)
 add_subdirectory(include)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-SET(JSON_FILES 
+SET(JSON_FILES
     src/jsoncpp.cpp
-    include/json.h
-    include/json-forwards.h
+    include/json/json.h
+    include/json/json-forwards.h
 )
 
 SET(SOURCE_FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ message(STATUS "LLVM definitions: ${LLVM_DEFINITIONS}")
 
 add_subdirectory(src)
 add_subdirectory(include)
+include_directories(${CMAKE_SOURCE_DIR}/include)
 
 SET(JSON_FILES 
     src/jsoncpp.cpp

--- a/double_free/double_free.c
+++ b/double_free/double_free.c
@@ -84,14 +84,14 @@ void __INSTR_fsm_change_state(fsm_id id, fsm_alphabet action) {
 		m->state = fsm_transition_table[m->state][action];
 	} else {
 		if (action == FSM_ALPHABET_FREE) {
-			assert(0);
+			assert(0 && "free on non-allocated memory");
 			//exit(EXIT_FAILURE);
 		}
 		m = __INSTR_fsm_create(id, FSM_STATE_ALLOCATED);
 	}
 
 	if (m->state == FSM_STATE_ERROR) {
-	        assert(0);
+	        assert(0 && "double free");
 		//exit(EXIT_FAILURE);
 	}
 }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,6 +1,6 @@
-install(FILES json.h
+install(FILES json/json.h
 	DESTINATION ${INSTALL_INC_DIR}/json)
 
-install(FILES json-forwards.h
+install(FILES json/json-forwards.h
 	DESTINATION ${INSTALL_INC_DIR}/json)
-	
+

--- a/include/json/json-forwards.h
+++ b/include/json/json-forwards.h
@@ -90,6 +90,7 @@ license you like.
 
 #ifndef JSON_CONFIG_H_INCLUDED
 #define JSON_CONFIG_H_INCLUDED
+#include <stddef.h>
 
 /// If defined, indicates that json library is embedded in CppTL library.
 //# define JSON_IN_CPPTL 1
@@ -141,33 +142,66 @@ license you like.
 // Storages, and 64 bits integer support is disabled.
 // #define JSON_NO_INT64 1
 
-#if defined(_MSC_VER) && _MSC_VER <= 1200 // MSVC 6
-// Microsoft Visual Studio 6 only support conversion from __int64 to double
-// (no conversion from unsigned __int64).
-#define JSON_USE_INT64_DOUBLE_CONVERSION 1
-// Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
-// characters in the debug information)
-// All projects I've ever seen with VS6 were using this globally (not bothering
-// with pragma push/pop).
-#pragma warning(disable : 4786)
-#endif // if defined(_MSC_VER)  &&  _MSC_VER < 1200 // MSVC 6
+#if defined(_MSC_VER) // MSVC
+#  if _MSC_VER <= 1200 // MSVC 6
+    // Microsoft Visual Studio 6 only support conversion from __int64 to double
+    // (no conversion from unsigned __int64).
+#    define JSON_USE_INT64_DOUBLE_CONVERSION 1
+    // Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
+    // characters in the debug information)
+    // All projects I've ever seen with VS6 were using this globally (not bothering
+    // with pragma push/pop).
+#    pragma warning(disable : 4786)
+#  endif // MSVC 6
 
-#if defined(_MSC_VER) && _MSC_VER >= 1500 // MSVC 2008
-/// Indicates that the following function is deprecated.
-#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
-#elif defined(__clang__) && defined(__has_feature)
-#if __has_feature(attribute_deprecated_with_message)
-#define JSONCPP_DEPRECATED(message)  __attribute__ ((deprecated(message)))
+#  if _MSC_VER >= 1500 // MSVC 2008
+    /// Indicates that the following function is deprecated.
+#    define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
+#  endif
+
+#endif // defined(_MSC_VER)
+
+
+#ifndef JSON_HAS_RVALUE_REFERENCES
+
+#if defined(_MSC_VER) && _MSC_VER >= 1600 // MSVC >= 2010
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif // MSVC >= 2010
+
+#ifdef __clang__
+#if __has_feature(cxx_rvalue_references)
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif  // has_feature
+
+#elif defined __GNUC__ // not clang (gcc comes later since clang emulates gcc)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif  // GXX_EXPERIMENTAL
+
+#endif // __clang__ || __GNUC__
+
+#endif // not defined JSON_HAS_RVALUE_REFERENCES
+
+#ifndef JSON_HAS_RVALUE_REFERENCES
+#define JSON_HAS_RVALUE_REFERENCES 0
 #endif
-#elif defined(__GNUC__) &&  (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
-#define JSONCPP_DEPRECATED(message)  __attribute__ ((deprecated(message)))
-#elif defined(__GNUC__) &&  (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
-#define JSONCPP_DEPRECATED(message)  __attribute__((__deprecated__))
-#endif
+
+#ifdef __clang__
+#elif defined __GNUC__ // not clang (gcc comes later since clang emulates gcc)
+#  if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+#    define JSONCPP_DEPRECATED(message)  __attribute__ ((deprecated(message)))
+#  elif (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
+#    define JSONCPP_DEPRECATED(message)  __attribute__((__deprecated__))
+#  endif  // GNUC version
+#endif // __clang__ || __GNUC__
 
 #if !defined(JSONCPP_DEPRECATED)
 #define JSONCPP_DEPRECATED(message)
 #endif // if !defined(JSONCPP_DEPRECATED)
+
+#if __GNUC__ >= 6
+#  define JSON_USE_INT64_DOUBLE_CONVERSION 1
+#endif
 
 namespace Json {
 typedef int Int;

--- a/instr
+++ b/instr
@@ -175,9 +175,9 @@ if __name__ == "__main__":
 
 	configFile = args[0]
 	cFile = args[1]
-	fileToLink = parseJson()
+	fileToLink = os.path.join(os.path.dirname(configFile), parseJson())
 	run()
-	
+
 	sys.stderr.flush()
 	sys.stdout.flush()
 

--- a/instr
+++ b/instr
@@ -137,7 +137,7 @@ def run():
 			err('Linking files failed!')
 			return
 		else:
-			dbg('Surce files linked.')
+			dbg('Source files linked.')
 	else:
 		ret = call(['clang -S -emit-llvm -o {0} {1}'.format(bcSourceFile, cFile)], shell=True)
 		if ret != 0:

--- a/null_deref/config.json
+++ b/null_deref/config.json
@@ -1,4 +1,4 @@
-{	
+{
 	"file": "null_deref.c",
 	"rules":
 	[
@@ -15,7 +15,22 @@
 					  },
 			"where": "before",
 			"in": "*"
+		},
+        {
+			"findInstruction": {
+					      "returnValue": "*",
+					      "instruction": "store",
+					      "operands": ["<t1>", "<t2>"]
+					   },
+			"newInstruction": {
+					      "returnValue": "*",
+					      "instruction": "call",
+					      "operands": ["<t2>", "__INSTR_check_pointer"]
+					  },
+			"where": "before",
+			"in": "*"
 		}
+
 	]
 }
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,13 @@
 ﻿
-Download 
-https://github.com/open-source-parsers/jsoncpp
-and install it into `include/` folder, move `jsoncpp.cpp` into `src` and modify `#include "json.h"` to `#include "../include/json.h"`. 
+Download
+https://github.com/open-source-parsers/jsoncpp and amalgamate the `jsonccp.cpp` source:
+```
+cd jsoncpp
+python amalgamate.py
+```
+Move newly created `jsoncpp.cpp` into `LLVMInstrument/src` folder.
+Then cofigure the project using `cmake` and build it in the usual way
+using `make`.
 
 Run script `instr`.
 

--- a/src/rewriter.cpp
+++ b/src/rewriter.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include "../lib/rewriter.hpp"
-#include "../include/json.h"
+#include "json/json.h"
 
 using namespace std;
 


### PR DESCRIPTION
* change json integration so that we don't need to modify jsoncpp.cpp (and reflect that in the readme)
* change for null dereference even in store instructions